### PR TITLE
feat: create orderDoneScreen

### DIFF
--- a/src/navigation/DetailNavigator.tsx
+++ b/src/navigation/DetailNavigator.tsx
@@ -1,7 +1,8 @@
+import MarketDetailScreen from '@/screens/MarketDetailScreen';
+import OrderDoneScreen from '@/screens/OrderDoneScreen';
 import PaymentScreen from '@/screens/PaymentScreen';
 import {DetailStackParamList} from '@/types/StackNavigationType';
 import {createStackNavigator} from '@react-navigation/stack';
-import MarketDetailScreen from '@/screens/MarketDetailScreen';
 import React from 'react';
 
 const Stack = createStackNavigator<DetailStackParamList>();
@@ -14,7 +15,7 @@ const DetailNavigator = () => {
       <Stack.Screen name="Market" component={MarketDetailScreen} />
       {/* <Stack.Screen name="Order" component={OrderScreen} /> */}
       <Stack.Screen name="Payment" component={PaymentScreen} />
-      {/* <Stack.Screen name="OrderDone" component={OrderDoneScreen} /> */}
+      <Stack.Screen name="OrderDone" component={OrderDoneScreen} />
     </Stack.Navigator>
   );
 };

--- a/src/screens/OrderDoneScreen/OrderDoneScreen.style.tsx
+++ b/src/screens/OrderDoneScreen/OrderDoneScreen.style.tsx
@@ -1,0 +1,16 @@
+import styled from '@emotion/native';
+import {Card} from 'react-native-paper';
+
+const OrderDoneCard = styled(Card)`
+  padding: 16px;
+  margin: 8px;
+
+  display: flex;
+  flex-direction: column;
+
+  background-color: white;
+`;
+
+const S = {OrderDoneCard};
+
+export default S;

--- a/src/screens/OrderDoneScreen/index.tsx
+++ b/src/screens/OrderDoneScreen/index.tsx
@@ -1,0 +1,27 @@
+import {DetailStackParamList} from '@/types/StackNavigationType';
+import {StackScreenProps} from '@react-navigation/stack';
+import React from 'react';
+import {Text, View} from 'react-native';
+import {Button, Title} from 'react-native-paper';
+import S from './OrderDoneScreen.style';
+
+type Props = StackScreenProps<DetailStackParamList, 'OrderDone'>;
+
+const OrderDoneScreen = ({navigation, route}: Props) => {
+  const {orderId} = route.params;
+
+  return (
+    <S.OrderDoneCard>
+      <Title>주문완료</Title>
+      <View>
+        <Text>주문이 완료되었습니다.</Text>
+        <Text>{`주문번호: ${orderId}`}</Text>
+      </View>
+      <Button onPress={() => navigation.navigate('Home', {screen: 'Feed'})}>
+        <Text>홈으로</Text>
+      </Button>
+    </S.OrderDoneCard>
+  );
+};
+
+export default OrderDoneScreen;

--- a/src/screens/PaymentScreen/PaymentPage.tsx
+++ b/src/screens/PaymentScreen/PaymentPage.tsx
@@ -1,12 +1,14 @@
 import {CartType} from '@/types/OrderType';
+import {RootStackParamList} from '@/types/StackNavigationType';
 import {BottomButton} from '@components/common';
 import {
   DatePickerCard,
   PaymentMethod,
   PaymentSummary,
 } from '@components/orderPage';
+import {useNavigation} from '@react-navigation/native';
+import {StackNavigationProp} from '@react-navigation/stack';
 import React, {useMemo, useState} from 'react';
-import {Alert} from 'react-native';
 import S from './PaymentPage.style';
 
 const paymentMethodKind = {
@@ -20,6 +22,7 @@ type Props = {cart: CartType};
 
 const PaymentPage = ({cart}: Props) => {
   const [method, setMethod] = useState<PaymentMethodKindKeyType>('toss');
+  const navigation = useNavigation<StackNavigationProp<RootStackParamList>>();
 
   const {originalPrice, discountPrice} = useMemo(
     () =>
@@ -47,7 +50,13 @@ const PaymentPage = ({cart}: Props) => {
           discountPrice={discountPrice}
         />
       </S.ScrollView>
-      <BottomButton onPress={() => Alert.alert(`${method}로 결제하기로 이동`)}>
+      <BottomButton
+        onPress={() =>
+          navigation.navigate('Detail', {
+            screen: 'OrderDone',
+            params: {orderId: 1},
+          })
+        }>
         {`${discountPrice.toLocaleString()}원 결제하기`}
       </BottomButton>
     </S.PaymentPage>

--- a/src/types/StackNavigationType.ts
+++ b/src/types/StackNavigationType.ts
@@ -18,6 +18,7 @@ export interface RegisterStackParamList extends ParamListBase {
 export interface DetailStackParamList extends ParamListBase {
   Market: {marketId: number};
   Payment: undefined;
+  OrderDone: {orderId: number};
 }
 
 export interface RootStackParamList extends ParamListBase {


### PR DESCRIPTION
## #️⃣연관된 이슈

resolves: #11 

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 결제하기 페이지 간단히 구현합니다.
- 결제 완료 시 홈으로 돌아갈 수 있게합니다.
- `useNavigation` 사용하면 props drilling 없이 네비게이션할 수 있네요.

```
import {useNavigation} from '@react-navigation/native';

const navigation = useNavigation<StackNavigationProp<RootStackParamList>>();
```

### 스크린샷 (선택)

| ![Screenshot_1727416443](https://github.com/user-attachments/assets/42d1ef39-ecc1-4a56-a880-22cd1998ebce) |
| - |


## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
